### PR TITLE
Add option for displaying tag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ _Here `grapple-line.nvim` is used on the right of the tabline._
 		-- "unique_filename" shows the filename and parent directories if needed
 		-- "filename" shows the filename only
 		mode = "unique_filename",
+		-- If a custom tag name is set, use that instead of the filename
+		show_names = false,
 	},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ _Here `grapple-line.nvim` is used on the right of the tabline._
 
 ### Full
 
+The default values are shown in the `opts` table.
+
 ```lua
 {
 	"will-lynas/grapple-line.nvim",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The default values are shown in the `opts` table.
 		-- "unique_filename" shows the filename and parent directories if needed
 		-- "filename" shows the filename only
 		mode = "unique_filename",
-		-- If a custom tag name is set, use that instead of the filename
+		-- If a tag name is set, use that instead of the filename
 		show_names = false,
 	},
 }

--- a/lua/grapple-line.lua
+++ b/lua/grapple-line.lua
@@ -10,7 +10,7 @@ M.settings = {
 	-- "unique_filename" shows the filename and parent directories if needed
 	-- "filename" shows the filename only
 	mode = "unique_filename",
-	-- If a custom tag name is set, use that instead of the filename
+	-- If a tag name is set, use that instead of the filename
 	show_names = false,
 }
 

--- a/lua/grapple-line.lua
+++ b/lua/grapple-line.lua
@@ -56,8 +56,9 @@ end
 local function get_counts(files)
 	local counts = {}
 	for _, file in ipairs(files) do
+		counts[file.name] = counts[file.name] or 0
 		if not file.tag_name then
-			counts[file.name] = (counts[file.name] or 0) + 1
+			counts[file.name] = counts[file.name] + 1
 		end
 	end
 	return counts

--- a/lua/grapple-line.lua
+++ b/lua/grapple-line.lua
@@ -10,6 +10,8 @@ M.settings = {
 	-- "unique_filename" shows the filename and parent directories if needed
 	-- "filename" shows the filename only
 	mode = "unique_filename",
+	-- If a custom tag name is set, use that instead of the filename
+	show_names = false,
 }
 
 function M.setup(user_settings)

--- a/lua/grapple-line.lua
+++ b/lua/grapple-line.lua
@@ -56,7 +56,9 @@ end
 local function get_counts(files)
 	local counts = {}
 	for _, file in ipairs(files) do
-		counts[file.name] = (counts[file.name] or 0) + 1
+		if not file.tag_name then
+			counts[file.name] = (counts[file.name] or 0) + 1
+		end
 	end
 	return counts
 end

--- a/lua/grapple-line.lua
+++ b/lua/grapple-line.lua
@@ -27,8 +27,9 @@ local function get_grapple_files()
 		if not grapple.exists({ index = i }) then
 			break
 		end
-		local path = grapple.find({ index = i }).path
-		local file = { path = path, current = path == current_path }
+		local tag = grapple.find({ index = i })
+		local path = tag.path
+		local file = { path = path, current = path == current_path, tag_name = tag.name }
 		table.insert(files, file)
 	end
 
@@ -39,7 +40,15 @@ local function make_statusline(files)
 	local result = {}
 	for _, file in ipairs(files) do
 		local color = file.current and M.settings.colors.active or M.settings.colors.inactive
-		table.insert(result, "%#" .. color .. "# " .. file.name .. " %*")
+
+		local text = ""
+		if file.tag_name and M.settings.show_names then
+			text = "[" .. file.tag_name .. "]"
+		else
+			text = file.name
+		end
+
+		table.insert(result, "%#" .. color .. "# " .. text .. " %*")
 	end
 	return table.concat(result)
 end


### PR DESCRIPTION
This PR addresses #4.

The `show_names` option is added. It is disabled by default to keep backwards compatibility.

If a tag has a name set, this will be used instead of the filename. The tag name is wrapped in square brackets to differentiate it from a file name. E.g. `[button]`. 