### PR TITLE
fix(display): allow Windows backslash

### DIFF
--- a/lua/grapple-line.lua
+++ b/lua/grapple-line.lua
@@ -156,7 +156,7 @@ end
 local function get_name(path, depth)
 	depth = depth or 1
 	local parts = {}
-	for part in string.gmatch(path, "[^/]+") do
+	for part in string.gmatch(path, "[^/\\]+") do
 		table.insert(parts, part)
 	end
 


### PR DESCRIPTION
Allow splitting paths using `\` so Windows paths display properly.

## Before
![image](https://github.com/user-attachments/assets/957f297f-76d4-4512-b2fb-62f469dc4d38)

## After
![image](https://github.com/user-attachments/assets/efca99b0-9905-4e81-af17-844ceb7e6056)

Alternatively instead it could run `path = vim.fs.normalize(path)` and that would also work.